### PR TITLE
Upgrade PostgreSQL to 16 and complete Module 1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,59 @@ This project is being systematically production-hardened as a hands-on SRE/DevOp
 
 ## Development
 
-### Quick Start
+### Prerequisites
+
+| Dependency | Version | Notes                                  |
+| ---------- | ------- | -------------------------------------- |
+| Node.js    | 22+     | Dockerfiles pin 22; local dev ≥ 24     |
+| pnpm       | 10.30+  | Enforced via `packageManager`          |
+| Docker     | 20+     | For containerized workflow             |
+| PostgreSQL | 16      | Provided via Docker or install locally |
+
+### Environment Variables
+
+Copy the sample env files before starting:
 
 ```bash
-docker-compose up    # All services via Docker
-# or
-pnpm dev             # Run API + UI locally
+cp packages/api/.env.sample packages/api/.env
+cp packages/ui/.env.sample packages/ui/.env
 ```
+
+**API** (`packages/api/.env`):
+
+| Variable            | Description                                | Example                                                 |
+| ------------------- | ------------------------------------------ | ------------------------------------------------------- |
+| `POSTGRES_DB`       | Database name (used by Postgres image)     | `ttis_db`                                               |
+| `POSTGRES_USER`     | Database user (used by Postgres image)     | `postgres`                                              |
+| `POSTGRES_PASSWORD` | Database password (used by Postgres image) | `password`                                              |
+| `DATABASE_URL`      | Prisma connection string                   | `postgresql://postgres:password@localhost:5432/ttis_db` |
+
+**UI** (`packages/ui/.env`):
+
+| Variable              | Description              | Default                         |
+| --------------------- | ------------------------ | ------------------------------- |
+| `NEXT_PUBLIC_API_URL` | GraphQL API endpoint URL | `http://localhost:4000/graphql` |
+
+### Quick Start (Docker)
+
+```bash
+docker-compose up        # Starts API (:4000), UI (:3000), PostgreSQL (:5432), Adminer (:8080)
+```
+
+### Quick Start (Local)
+
+```bash
+pnpm install             # Install all dependencies
+docker-compose up ttis-db  # Start PostgreSQL only
+pnpm --filter @ttis/api exec prisma migrate dev  # Run database migrations
+pnpm dev                 # Start API + UI dev servers
+```
+
+### Verify It Works
+
+- UI: http://localhost:3000
+- GraphQL Playground: http://localhost:4000/playground
+- Adminer (DB GUI): http://localhost:8080
 
 ### Packages
 

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
 
   ttis-db:
     container_name: db
-    image: postgres:11.4-alpine
+    image: postgres:16-alpine
     restart: on-failure
     env_file: ./packages/api/.env
     volumes:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-**Last Updated:** 2026-03-25
+**Last Updated:** 2026-03-27
 
 **Active Module:** 1 — Containerization & Local Kubernetes
 
@@ -31,7 +31,7 @@ For full acceptance criteria, implementation checklists, and per-module notes, s
 | Frontend         | Next.js 16, React 19, Apollo Client, Tailwind v4 |                                  |
 | API              | GraphQL Yoga v5, Pothos v4, TypeScript           |                                  |
 | ORM              | Prisma v7                                        | Recently migrated from Sequelize |
-| Database         | PostgreSQL 11.4                                  | Upgrading to 16 (ADR-009)        |
+| Database         | PostgreSQL 16                                    | Upgraded from 11.4 (ADR-009)     |
 | Package Manager  | pnpm v10 (workspaces)                            |                                  |
 | Containerization | Docker + Docker Compose                          |                                  |
 
@@ -47,14 +47,12 @@ For full acceptance criteria, implementation checklists, and per-module notes, s
 
 ## Active Blockers
 
-These must be resolved before Module 2 work begins. They reflect the cost of modernizing the app (ORM migration, framework upgrades, package manager migration) concurrently with production planning.
+None — all Module 1 prerequisite blockers have been resolved:
 
-| Blocker                 | Description                                                                          | Module |
-| ----------------------- | ------------------------------------------------------------------------------------ | ------ |
-| Prisma client not wired | Schema defined but client not fully connected to DB; queries not verified end-to-end | 1      |
-| Seeding not working     | Prisma-based seed script exists but not verified against live DB                     | 1      |
-| Hardcoded Apollo URI    | UI points to `http://localhost:4000` — no environment-based config                   | 1      |
-| PostgreSQL 11.4 EOL     | Running an end-of-life database version; upgrading to 16                             | 1      |
+- ~~Prisma client not wired~~ — resolved; end-to-end queries verified
+- ~~Seeding not working~~ — resolved; Prisma seed script runs against live DB
+- ~~Hardcoded Apollo URI~~ — resolved; moved to `NEXT_PUBLIC_API_URL` env var
+- ~~PostgreSQL 11.4 EOL~~ — resolved; upgraded to PostgreSQL 16 (ADR-009)
 
 ## Active Module Detail
 

--- a/docs/modules/module-01-containerization.md
+++ b/docs/modules/module-01-containerization.md
@@ -17,18 +17,18 @@ Get the full application stack running in a local Kubernetes cluster with produc
 - [x] Audit current repo, get it running locally
 - [x] Reboot UI to use latest Next.js, TypeScript, Tailwind, and shadcn/ui
 - [x] Migrate API ORM from Sequelize to Prisma
-- [ ] Wire Prisma client to database and verify end-to-end queries
-- [ ] Get real initial data seeding working via Prisma
-- [ ] Upgrade PostgreSQL from 11.4 → 16 in docker-compose
-- [ ] Move Apollo Client URI to environment variable
-- [ ] Document all dependencies (Node version, DB version, env vars)
+- [x] Wire Prisma client to database and verify end-to-end queries
+- [x] Get real initial data seeding working via Prisma
+- [x] Upgrade PostgreSQL from 11.4 → 16 in docker-compose
+- [x] Move Apollo Client URI to environment variable
+- [x] Document all dependencies (Node version, DB version, env vars)
 
 ### Docker
 
-- [ ] Verify API container builds and runs
-- [ ] Verify UI container builds and runs
-- [ ] Verify full stack works via docker-compose
-- [ ] Update README with local setup instructions
+- [x] Verify API container builds and runs
+- [x] Verify UI container builds and runs
+- [x] Verify full stack works via docker-compose
+- [x] Update README with local setup instructions
 
 ### Kubernetes
 

--- a/packages/api/src/schema/venue.ts
+++ b/packages/api/src/schema/venue.ts
@@ -30,7 +30,8 @@ const AddVenueInput = builder.inputType("AddVenueInput", {
 builder.queryField("fetchVenues", (t) =>
   t.prismaField({
     type: ["Venue"],
-    resolve: (query) => prisma.venue.findMany({ ...query, include: { events: true } }),
+    resolve: (query) =>
+      prisma.venue.findMany({ ...query, include: { events: true } }),
   }),
 );
 


### PR DESCRIPTION
## Summary

- Upgrades `compose.yml` from `postgres:11.4-alpine` → `postgres:16-alpine`
- Adds comprehensive Development section to root README (prerequisites, env vars, local & Docker setup, verification URLs)
- Marks all Module 1 prerequisite and Docker checklist items as complete
- Clears stale active-blockers table in STATUS.md

## Test plan

- [x] `docker-compose up` starts all services with PostgreSQL 16
- [x] Verify README setup instructions are accurate end-to-end
- [x] Confirm Module 1 checklist and STATUS.md reflect current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)