### PR TITLE
Module 02: Add Turborepo with remote caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ Thumbs.db
 
 # AI
 .claude/worktrees
+
+# Turborepo
+.turbo

--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ kubectl port-forward -n ttis svc/ui 3000:3000
 ### Other Commands
 
 ```bash
-pnpm test                # Run tests across all packages (Vitest)
-pnpm lint                # Lint all packages
+pnpm test                # Run tests across all packages (Vitest, via Turbo)
+pnpm lint                # Lint all packages (via Turbo)
+pnpm types               # Type-check all packages with `tsc --noEmit` (via Turbo)
 pnpm format              # Format all packages (Prettier)
-pnpm build               # Build all packages
+pnpm build               # Build all packages (via Turbo, with remote cache)
 pnpm parse-csv           # Parse CSV data into JSON for seeding
 ```
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-**Last Updated:** 2026-04-03
+**Last Updated:** 2026-04-13
 
 **Active Module:** 2 — Build System & CI/CD Foundation
 
@@ -11,18 +11,18 @@
 
 For full acceptance criteria, implementation checklists, and per-module notes, see [`docs/modules/`](./modules/README.md).
 
-| Module                                            | Focus                                | Status         | Start Date | End Date |
-| ------------------------------------------------- | ------------------------------------ | -------------- | ---------- | -------- |
+| Module                                            | Focus                                | Status         | Start Date | End Date   |
+| ------------------------------------------------- | ------------------------------------ | -------------- | ---------- | ---------- |
 | [01](./modules/module-01-containerization.md)     | Containerization & Local Kubernetes  | ✅ Complete    | 2026-03-03 | 2026-04-03 |
-| [02](./modules/module-02-cicd.md)                 | Build System & CI/CD Foundation      | 🟡 In Progress |            |          |
-| [03](./modules/module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | ⬜ Not Started |            |          |
-| [04](./modules/module-04-auth.md)                 | Authentication & Authorization       | ⬜ Not Started |            |          |
-| [05](./modules/module-05-service-extraction.md)   | Service Extraction & Message Queue   | ⬜ Not Started |            |          |
-| [06](./modules/module-06-metrics-dashboards.md)   | Observability — Metrics & Dashboards | ⬜ Not Started |            |          |
-| [07](./modules/module-07-logging-tracing.md)      | Observability — Logging & Tracing    | ⬜ Not Started |            |          |
-| [08](./modules/module-08-alerting.md)             | Alerting & Incident Response         | ⬜ Not Started |            |          |
-| [09](./modules/module-09-gitops.md)               | GitOps & Advanced Deployment         | ⬜ Not Started |            |          |
-| [10](./modules/module-10-chaos.md)                | Chaos Engineering & Polish           | ⬜ Not Started |            |          |
+| [02](./modules/module-02-cicd.md)                 | Build System & CI/CD Foundation      | 🟡 In Progress | 2026-04-13 |            |
+| [03](./modules/module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | ⬜ Not Started |            |            |
+| [04](./modules/module-04-auth.md)                 | Authentication & Authorization       | ⬜ Not Started |            |            |
+| [05](./modules/module-05-service-extraction.md)   | Service Extraction & Message Queue   | ⬜ Not Started |            |            |
+| [06](./modules/module-06-metrics-dashboards.md)   | Observability — Metrics & Dashboards | ⬜ Not Started |            |            |
+| [07](./modules/module-07-logging-tracing.md)      | Observability — Logging & Tracing    | ⬜ Not Started |            |            |
+| [08](./modules/module-08-alerting.md)             | Alerting & Incident Response         | ⬜ Not Started |            |            |
+| [09](./modules/module-09-gitops.md)               | GitOps & Advanced Deployment         | ⬜ Not Started |            |            |
+| [10](./modules/module-10-chaos.md)                | Chaos Engineering & Polish           | ⬜ Not Started |            |            |
 
 ## Current Stack
 
@@ -48,6 +48,7 @@ For full acceptance criteria, implementation checklists, and per-module notes, s
 - Liveness/readiness probes and resource limits on all K8s deployments
 - Prisma migration Job for database schema deployment in K8s
 - Seed data pipeline: CSV → JSON → Prisma seed script (~500 concert records)
+- Turborepo task pipelines (build, lint, test, types) with Vercel remote caching
 
 ## Active Blockers
 
@@ -60,4 +61,4 @@ None — all Module 1 prerequisite blockers have been resolved:
 
 ## Active Module Detail
 
-See [Module 01](./modules/module-01-containerization.md) for the full acceptance criteria checklist and in-progress notes.
+See [Module 02](./modules/module-02-cicd.md) for the full acceptance criteria checklist and in-progress notes.

--- a/docs/modules/module-02-cicd.md
+++ b/docs/modules/module-02-cicd.md
@@ -1,8 +1,8 @@
 # Module 02: Build System & CI/CD Foundation
 
-**Status:** ⬜ Not Started
+**Status:** 🟡 In Progress
 
-**Start Date:** —
+**Start Date:** 2026-04-13
 
 **End Date:** —
 
@@ -14,11 +14,11 @@ Establish a fast, reliable CI pipeline using Turborepo for monorepo-aware build 
 
 ### Turborepo
 
-- [ ] Install Turborepo (`pnpm add -Dw turbo`)
-- [ ] Create `turbo.json` with task pipelines (build, lint, test, dev)
-- [ ] Verify `turbo run build` respects package dependency order
-- [ ] Set up remote caching (Vercel free tier or self-hosted)
-- [ ] Update root `package.json` scripts to use `turbo run`
+- [x] Install Turborepo (`pnpm add -Dw turbo`)
+- [x] Create `turbo.json` with task pipelines (build, lint, test, types, dev)
+- [x] Verify `turbo run build` respects package dependency order
+- [x] Set up remote caching (Vercel free tier or self-hosted)
+- [x] Update root `package.json` scripts to use `turbo run`
 
 ### Production Dockerfiles
 
@@ -54,3 +54,8 @@ _None yet. Add links here as decisions are made during this module._
 ## Notes & Discoveries
 
 > Capture decisions made on the fly, unexpected findings, or context that doesn't warrant a full ADR. Append entries as you go.
+
+### 2026-04-13 — Turborepo setup
+
+- Remote caching uses the Vercel free tier; CI will need `TURBO_TOKEN` and `TURBO_TEAM` as GitHub Actions secrets when we wire up the CI Pipeline section.
+- Split `tsc --noEmit` out of the API `lint` script into a dedicated `types` task (with a matching script on `@ttis/ui`) so type checks can run independently of linting in CI.

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "dev:infra:down": "docker compose -f compose.dev.yml down",
     "prod": "docker compose -f compose.prod.yml up --build",
     "prod:down": "docker compose -f compose.prod.yml down",
-    "test": "pnpm -r run test",
+    "test": "turbo run test",
     "format": "pnpm -r run format",
-    "lint": "pnpm -r run lint",
-    "build": "pnpm -r run build",
+    "lint": "turbo run lint",
+    "types": "turbo run types",
+    "build": "turbo run build",
     "parse-csv": "tsx data/scripts/parse-csv.ts",
     "prepare": "husky"
   },
@@ -21,7 +22,8 @@
     "csv-parse": "^6.1.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.3",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "turbo": "^2.9.6"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,8 @@
   "main": "src/index.js",
   "scripts": {
     "dev": "tsx watch ./src/",
-    "lint": "tsc --noEmit && eslint ./src/ --quiet --fix",
+    "lint": "eslint ./src/ --quiet --fix",
+    "types": "tsc --noEmit",
     "build": "pnpm run generate && tsc",
     "start": "node ./build/src/index.js",
     "generate": "prisma generate",
@@ -21,7 +22,7 @@
     "prisma": "prisma  --config ./prisma/prisma.config.ts",
     "db:reset": "pnpm run prisma migrate reset",
     "db:seed": "pnpm run prisma db seed",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest dev"
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",
-    "lint": "eslint"
+    "lint": "eslint",
+    "types": "tsc --noEmit"
   },
   "dependencies": {
     "@apollo/client": "^4.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      turbo:
+        specifier: ^2.9.6
+        version: 2.9.6
 
   packages/api:
     dependencies:
@@ -2348,6 +2351,36 @@ packages:
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -7063,6 +7096,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -9810,6 +9847,24 @@ snapshots:
       minimatch: 10.2.4
       path-browserify: 1.0.1
 
+  '@turbo/darwin-64@2.9.6':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.6':
+    optional: true
+
+  '@turbo/linux-64@2.9.6':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.6':
+    optional: true
+
+  '@turbo/windows-64@2.9.6':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.6':
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -11688,7 +11743,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -11729,7 +11784,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11743,7 +11798,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15293,6 +15348,15 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  turbo@2.9.6:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6
 
   tw-animate-css@1.4.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["build/**", ".next/**", "!.next/cache/**", "src/generated/**"]
+    },
+    "lint": {
+      "dependsOn": ["^build"]
+    },
+    "types": {
+      "dependsOn": ["^build"]
+    },
+    "test": {
+      "dependsOn": ["^build"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Wires up Turborepo for monorepo-aware task orchestration across `@ttis/api` and `@ttis/ui`, with `build`, `lint`, `test`, `types`, and `dev` pipelines.
- Enables Vercel remote caching so builds/lints/tests can be shared between local machines and (soon) CI.
- Splits `tsc --noEmit` out of the API `lint` script into a dedicated `types` task (matching script added to `@ttis/ui`) so type checks can run independently of linting in CI.
- Completes the Turborepo section of [Module 02](docs/modules/module-02-cicd.md).

## Test plan

- [x] `pnpm build` — builds both packages via Turbo, cache hits on warm runs (`>>> FULL TURBO`)
- [x] `pnpm lint` — lints both packages via Turbo
- [x] `pnpm types` — runs `tsc --noEmit` across both packages
- [x] `pnpm test` — exits 0 via Turbo (API uses `--passWithNoTests` until real tests exist)
- [x] Remote cache verified: after `--force` rebuild, subsequent run replays logs from Vercel remote cache with "Remote caching enabled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)