### PR TITLE
Module 02: Add ECR publish workflow + AWS setup scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -44,3 +47,56 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  publish:
+    name: Publish ${{ matrix.target }} to ECR
+    if: github.event_name == 'push'
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - target: api
+            repo: ttis-api
+          - target: ui
+            repo: ttis-ui
+    env:
+      ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.ECR_REGISTRY }}/${{ matrix.repo }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ graph TD
 
 - **Compute:** AWS EKS (Elastic Kubernetes Service)
 - **Database:** AWS RDS (PostgreSQL 16)
-- **Container Registry:** GitHub Container Registry (ghcr.io) for dev; AWS ECR for production
+- **Container Registry:** AWS ECR (single registry for all environments; OIDC auth from CI; native EKS IAM pulls)
 - **DNS:** AWS Route53
 - **Ingress:** nginx-ingress controller via Helm
 - **Secrets:** Kubernetes Secrets or AWS Secrets Manager
@@ -123,7 +123,7 @@ graph TD
     PR([PR Opened])
     CI["GitHub Actions<br/>install · lint · typecheck · test · build<br/>Turborepo cache"]
     Merge([Merge to main])
-    Push["Build & push Docker images<br/>ghcr.io / ECR<br/>tagged: git SHA + latest"]
+    Push["Build & push Docker images<br/>AWS ECR<br/>tagged: git SHA + latest"]
     Argo[ArgoCD detects<br/>manifest change]
     Deploy["Deploy to EKS<br/>canary → full rollout"]
     Smoke{Smoke tests}
@@ -187,18 +187,18 @@ Failed enrichment attempts are retried via RabbitMQ dead letter queue with expon
 
 Full acceptance criteria, implementation checklists, and per-module notes live in [`docs/modules/`](./modules/README.md). This table is the high-level overview.
 
-| Module                                            | Focus                                | Status         | Target Outcome                                                           |
-| ------------------------------------------------- | ------------------------------------ | -------------- | ------------------------------------------------------------------------ |
-| [01](./modules/module-01-containerization.md)     | Containerization & Local Kubernetes  | 🟡 In Progress | Full stack running in local k8s with probes and resource limits          |
-| [02](./modules/module-02-cicd.md)                 | Build System & CI/CD Foundation      | ⬜ Not Started | Turborepo build cache, GitHub Actions CI, images published to ghcr.io    |
-| [03](./modules/module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | ⬜ Not Started | EKS cluster + RDS provisioned via Terraform, app accessible at real URL  |
-| [04](./modules/module-04-auth.md)                 | Authentication & Authorization       | ⬜ Not Started | Auth.js with Google OAuth, JWT-protected GraphQL API, session management |
-| [05](./modules/module-05-service-extraction.md)   | Service Extraction & Message Queue   | ⬜ Not Started | Enrichment service deployed, RabbitMQ running, async flow end-to-end     |
-| [06](./modules/module-06-metrics-dashboards.md)   | Observability — Metrics & Dashboards | ⬜ Not Started | Prometheus + Grafana, RED method dashboards per service                  |
-| [07](./modules/module-07-logging-tracing.md)      | Observability — Logging & Tracing    | ⬜ Not Started | Loki + Tempo via OTel, SLO compliance dashboards                         |
-| [08](./modules/module-08-alerting.md)             | Alerting & Incident Response         | ⬜ Not Started | SLO-based alerts, runbooks, chaos day postmortem                         |
-| [09](./modules/module-09-gitops.md)               | GitOps & Advanced Deployment         | ⬜ Not Started | ArgoCD, canary deployments, Terraform in CI, image scanning              |
-| [10](./modules/module-10-chaos.md)                | Chaos Engineering & Polish           | ⬜ Not Started | Automated chaos experiments, cost optimization, portfolio polish         |
+| Module                                            | Focus                                | Target Outcome                                                           |
+| ------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------ |
+| [01](./modules/module-01-containerization.md)     | Containerization & Local Kubernetes  | Full stack running in local k8s with probes and resource limits          |
+| [02](./modules/module-02-cicd.md)                 | Build System & CI/CD Foundation      | Turborepo build cache, GitHub Actions CI, images published to ECR        |
+| [03](./modules/module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | EKS cluster + RDS provisioned via Terraform, app accessible at real URL  |
+| [04](./modules/module-04-auth.md)                 | Authentication & Authorization       | Auth.js with Google OAuth, JWT-protected GraphQL API, session management |
+| [05](./modules/module-05-service-extraction.md)   | Service Extraction & Message Queue   | Enrichment service deployed, RabbitMQ running, async flow end-to-end     |
+| [06](./modules/module-06-metrics-dashboards.md)   | Observability — Metrics & Dashboards | Prometheus + Grafana, RED method dashboards per service                  |
+| [07](./modules/module-07-logging-tracing.md)      | Observability — Logging & Tracing    | Loki + Tempo via OTel, SLO compliance dashboards                         |
+| [08](./modules/module-08-alerting.md)             | Alerting & Incident Response         | SLO-based alerts, runbooks, chaos day postmortem                         |
+| [09](./modules/module-09-gitops.md)               | GitOps & Advanced Deployment         | ArgoCD, canary deployments, Terraform in CI, image scanning              |
+| [10](./modules/module-10-chaos.md)                | Chaos Engineering & Polish           | Automated chaos experiments, cost optimization, portfolio polish         |
 
 ## 4. Technology Decisions
 
@@ -227,7 +227,7 @@ Full acceptance criteria, implementation checklists, and per-module notes live i
 | CI/CD               | GitHub Actions                | Native to existing GitHub repo; no additional tooling required                                                                       |
 | GitOps              | ArgoCD                        | CNCF graduated; declarative; pairs cleanly with Kubernetes manifests                                                                 |
 | Build orchestration | Turborepo                     | Monorepo-aware build caching; reduces CI time as package count grows                                                                 |
-| Container registry  | ghcr.io (dev) → ECR (prod)    | GitHub-native for development; ECR integrates with EKS IAM for production                                                            |
+| Container registry  | AWS ECR                       | Single registry for all environments; OIDC auth from CI; native EKS IAM integration for pulls                                        |
 
 ## 5. ADR Log
 

--- a/docs/adr/0011-ecr-over-ghcr.md
+++ b/docs/adr/0011-ecr-over-ghcr.md
@@ -1,0 +1,37 @@
+# ADR-0011: Use AWS ECR as the Single Container Registry
+
+Date: 2026-04-20
+
+Status: Accepted
+
+## Context
+
+Module 02 originally targeted GitHub Container Registry (ghcr.io) for Docker image publishing. The production architecture targets AWS EKS (Module 03+), which integrates natively with ECR via IAM roles for service accounts — EKS nodes can pull images from ECR without explicit credentials or `imagePullSecret` configuration.
+
+Using ghcr.io would require:
+
+- Configuring Kubernetes `imagePullSecrets` in every namespace/service account
+- Managing a separate credential rotation lifecycle
+- Paying cross-network egress on every pod scale-up
+- A mid-project registry migration when moving to production
+
+The project is on the AWS Free Tier, which provides 500MB of private ECR storage for 12 months.
+
+## Decision
+
+Use AWS ECR as the single container registry for all environments. Two private repositories (`ttis-api`, `ttis-ui`) store images tagged with git SHA and `latest`.
+
+Authentication from GitHub Actions uses OIDC federation — the workflow requests a JWT from GitHub's identity provider and exchanges it with AWS STS for temporary credentials. No long-lived AWS access keys are stored as GitHub secrets.
+
+Lifecycle policies enforce storage hygiene:
+
+- Untagged images expire after 1 day
+- Only the last 5 tagged images are retained per repository
+
+## Consequences
+
+- **Simpler Kubernetes config:** EKS nodes pull from ECR via IAM — no `imagePullSecret` plumbing.
+- **No credential rotation:** OIDC tokens are short-lived and generated per workflow run. The AWS account ID is stored as a GitHub secret (not a variable) to keep it masked in public Actions logs.
+- **Free Tier discipline:** Lifecycle policies are mandatory. Without them, SHA-tagged images accumulate and exceed 500MB within a few merges.
+- **One-time setup required:** OIDC provider, IAM role, and ECR repositories must be created before the CI publish job will succeed. Setup is scripted in `scripts/setup-ecr-repos.sh` and `scripts/setup-github-oidc.sh`.
+- **Vendor coupling:** Images are in AWS-specific infrastructure. Acceptable given the project is fully committed to AWS for compute (EKS), database (RDS), and DNS (Route53).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ To add a new ADR, create a file named `NNNN-short-title.md` using the next avail
 | [0008](./0008-typescript-for-enrichment-service.md)  | Use TypeScript for the Enrichment Service (Go Deferred)    | 2026-03-25 | Accepted |
 | [0009](./0009-postgresql-version-upgrade.md)         | Upgrade PostgreSQL from 11.4 to 16                         | 2026-03-25 | Accepted |
 | [0010](./0010-k3d-local-kubernetes.md)               | Use k3d for Local Kubernetes Development                   | 2026-04-03 | Accepted |
+| [0011](./0011-ecr-over-ghcr.md)                      | Use AWS ECR as the Single Container Registry               | 2026-04-20 | Accepted |

--- a/docs/modules/module-02-cicd.md
+++ b/docs/modules/module-02-cicd.md
@@ -8,7 +8,7 @@
 
 ## Goal
 
-Establish a fast, reliable CI pipeline using Turborepo for monorepo-aware build caching and GitHub Actions for automated lint, test, and build checks. On merge to main, Docker images are built and published to GitHub Container Registry, ready for deployment.
+Establish a fast, reliable CI pipeline using Turborepo for monorepo-aware build caching and GitHub Actions for automated lint, test, and build checks. On merge to main, Docker images are built and published to AWS ECR, ready for deployment to EKS.
 
 ## Acceptance Criteria
 
@@ -40,19 +40,20 @@ Establish a fast, reliable CI pipeline using Turborepo for monorepo-aware build 
 
 ### Container Registry
 
-- [ ] Set up GitHub Container Registry (ghcr.io)
-- [ ] Add CI step to build and push Docker images on merge to main
+- [ ] Set up AWS ECR repositories (ttis-api, ttis-ui) with lifecycle policies
+- [ ] Configure GitHub OIDC for AWS IAM role assumption
+- [ ] Add CI step to build and push Docker images to ECR on merge to main
 - [ ] Tag images with git SHA and `latest`
-- [ ] Verify images are pullable from the registry
+- [ ] Verify images are pullable from ECR
 
 ### Verification
 
-- [ ] End-to-end: open PR → CI passes → merge → images published to ghcr.io
+- [ ] End-to-end: open PR → CI passes → merge → images published to ECR
 - [ ] Document pipeline architecture and caching strategy
 
 ## Related ADRs
 
-_None yet. Add links here as decisions are made during this module._
+- [ADR-0011](../adr/0011-ecr-over-ghcr.md) — Use AWS ECR as the single container registry
 
 ## Notes & Discoveries
 
@@ -73,3 +74,11 @@ _None yet. Add links here as decisions are made during this module._
 - Sourcing the Node version from `.nvmrc` via `actions/setup-node`'s `node-version-file` so CI, Docker, and dev all stay in lockstep from a single pin.
 - `TURBO_TOKEN` lives in repo secrets; `TURBO_TEAM` lives in repo variables (the team slug isn't sensitive).
 - Pinned `actions/checkout`, `actions/setup-node`, and `pnpm/action-setup` to `@v5` so the action runtimes sit on Node 24 ahead of the June 2026 Node 20 deprecation. Held off on `setup-node@v6` because it drops automatic pnpm caching, which would force a manual `actions/cache` step.
+
+### 2026-04-20 — Container registry: ECR over ghcr.io
+
+- Switched target container registry from ghcr.io to AWS ECR (see [ADR-0011](../adr/0011-ecr-over-ghcr.md)). Rationale: production targets EKS, and ECR integrates natively with EKS node IAM roles for image pulls — no `imagePullSecret` wiring. Using ECR from the start avoids a mid-project registry migration.
+- GitHub Actions authenticates to AWS via OIDC (no long-lived credentials). The `publish` job requests an `id-token` from GitHub's OIDC provider and exchanges it with AWS STS for temporary credentials scoped to ECR push only.
+- Lifecycle policies keep only the last 5 tagged images per repo (plus 1-day expiry for untagged) to stay within the Free Tier 500MB storage limit.
+- Docker layer caching uses the GitHub Actions cache backend (`type=gha`) rather than ECR inline cache — simpler, free, and avoids consuming ECR storage for cache layers.
+- One-time AWS setup is scripted: run `./scripts/setup-ecr-repos.sh` then `./scripts/setup-github-oidc.sh` (requires AWS CLI configured with admin access). After running, add the outputted secrets/variables to the GitHub repo settings.

--- a/scripts/setup-ecr-repos.sh
+++ b/scripts/setup-ecr-repos.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+REPOS=("ttis-api" "ttis-ui")
+
+LIFECYCLE_POLICY='{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Expire untagged images after 1 day",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 1
+      },
+      "action": { "type": "expire" }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Keep only last 5 tagged images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPatternList": ["*"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 5
+      },
+      "action": { "type": "expire" }
+    }
+  ]
+}'
+
+for repo in "${REPOS[@]}"; do
+  echo "Creating ECR repository: ${repo}..."
+  aws ecr create-repository \
+    --repository-name "$repo" \
+    --image-scanning-configuration scanOnPush=true \
+    --region "$REGION" \
+    2>/dev/null || echo "  Repository ${repo} already exists, skipping creation."
+
+  echo "Applying lifecycle policy to ${repo}..."
+  aws ecr put-lifecycle-policy \
+    --repository-name "$repo" \
+    --lifecycle-policy-text "$LIFECYCLE_POLICY" \
+    --region "$REGION"
+
+  echo ""
+done
+
+echo "Done. ECR repositories ready:"
+for repo in "${REPOS[@]}"; do
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  echo "  ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${repo}"
+done

--- a/scripts/setup-github-oidc.sh
+++ b/scripts/setup-github-oidc.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+ROLE_NAME="github-actions-ecr-push"
+GITHUB_REPO="${GITHUB_REPO:-jrinehart/the-things-ive-seen}"
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+OIDC_PROVIDER_URL="https://token.actions.githubusercontent.com"
+OIDC_PROVIDER_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+
+echo "AWS Account: ${ACCOUNT_ID}"
+echo "Region: ${REGION}"
+echo "GitHub repo: ${GITHUB_REPO}"
+echo ""
+
+echo "Creating OIDC identity provider..."
+aws iam create-open-id-connect-provider \
+  --url "$OIDC_PROVIDER_URL" \
+  --client-id-list sts.amazonaws.com \
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1 \
+  2>/dev/null || echo "  OIDC provider already exists, skipping."
+
+echo ""
+echo "Creating IAM role: ${ROLE_NAME}..."
+
+TRUST_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${OIDC_PROVIDER_ARN}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:${GITHUB_REPO}:ref:refs/heads/main"
+        }
+      }
+    }
+  ]
+}
+EOF
+)
+
+aws iam create-role \
+  --role-name "$ROLE_NAME" \
+  --assume-role-policy-document "$TRUST_POLICY" \
+  2>/dev/null || echo "  Role ${ROLE_NAME} already exists, skipping creation."
+
+echo "Attaching ECR push policy..."
+
+ECR_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["ecr:GetAuthorizationToken"],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Resource": [
+        "arn:aws:ecr:${REGION}:${ACCOUNT_ID}:repository/ttis-api",
+        "arn:aws:ecr:${REGION}:${ACCOUNT_ID}:repository/ttis-ui"
+      ]
+    }
+  ]
+}
+EOF
+)
+
+aws iam put-role-policy \
+  --role-name "$ROLE_NAME" \
+  --policy-name ecr-push-policy \
+  --policy-document "$ECR_POLICY"
+
+echo ""
+echo "Done. Configure these in your GitHub repository settings:"
+echo ""
+echo "  Secret:   AWS_ROLE_ARN   = arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+echo "  Secret:   AWS_ACCOUNT_ID = ${ACCOUNT_ID}"
+echo "  Variable: AWS_REGION     = ${REGION}"


### PR DESCRIPTION
## Summary

- Add `publish` job to CI workflow that builds `api` and `ui` Docker targets in parallel and pushes to AWS ECR on merge to main (OIDC auth, no long-lived credentials)
- Add setup scripts (`scripts/setup-ecr-repos.sh`, `scripts/setup-github-oidc.sh`) for one-time AWS provisioning of ECR repos, lifecycle policies, OIDC provider, and IAM role
- Switch all container registry references from ghcr.io to ECR (ADR-0011) — ECR integrates natively with EKS IAM for image pulls, avoiding imagePullSecret wiring
- Store `AWS_ACCOUNT_ID` as a GitHub secret (not variable) to keep it masked in public Actions logs
- Remove duplicated Status column from ARCHITECTURE.md module roadmap (tracked in STATUS.md)

## Test plan

- [x] CI job runs on this PR (publish job should **not** appear — it only triggers on push to main)
- [x] Run `./scripts/setup-ecr-repos.sh` to create ECR repos + lifecycle policies
- [x] Run `./scripts/setup-github-oidc.sh` to create OIDC provider + IAM role
- [x] Add `AWS_ROLE_ARN` and `AWS_ACCOUNT_ID` as GitHub secrets, `AWS_REGION` as a variable
- [ ] After merge: verify publish job runs and images appear in ECR (`aws ecr describe-images --repository-name ttis-api`)
- [ ] Verify lifecycle policies are active (`aws ecr get-lifecycle-policy --repository-name ttis-api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)