### PR TITLE
Module 02: Split production Dockerfiles per package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,8 @@
 **/build
 packages/api/lib
 **/.pnpm-store
-docs
-data
+
+**/docs
+**/data
+**/scripts
+**/k8s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: api
+          - package: api
             repo: ttis-api
-          - target: ui
+          - package: ui
             repo: ttis-ui
     env:
       ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
@@ -94,9 +94,9 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          target: ${{ matrix.target }}
+          file: packages/${{ matrix.package }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
+          cache-from: type=gha,scope=${{ matrix.package }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.package }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ UI (Apollo Client) → GraphQL API (GraphQL Yoga + Pothos) → Prisma ORM → Po
 
 ## Development URLs
 
-- GraphQL Playground: http://localhost:4000/playground
+- GraphQL endpoint (GraphiQL UI): http://localhost:4000/graphql
 - UI: http://localhost:3000
 - Adminer (DB GUI): http://localhost:8080
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -24,8 +24,7 @@ services:
     restart: on-failure
     build:
       context: .
-      dockerfile: Dockerfile
-      target: api
+      dockerfile: packages/api/Dockerfile
     environment:
       DATABASE_URL: postgresql://postgres:password@ttis-db:5432/ttis_db
     depends_on:
@@ -38,8 +37,7 @@ services:
     restart: on-failure
     build:
       context: .
-      dockerfile: Dockerfile
-      target: ui
+      dockerfile: packages/ui/Dockerfile
     environment:
       HOSTNAME: "0.0.0.0"
       PORT: "3000"

--- a/docs/modules/module-02-cicd.md
+++ b/docs/modules/module-02-cicd.md
@@ -22,14 +22,12 @@ Establish a fast, reliable CI pipeline using Turborepo for monorepo-aware build 
 
 ### Production Dockerfiles
 
-> [!NOTE]
-> This work landed in Module 01 (commit `9582946 Split dev/prod Docker workflows with pnpm deploy`). The monorepo uses a single root `Dockerfile` with multi-stage builds and `--target api` / `--target ui` rather than per-package Dockerfiles — the `build` stage installs deps and builds both packages once, and `pnpm deploy` prunes a per-package `node_modules` for each runner stage. This section is an audit-and-verify pass on what already exists.
-
-- [x] Audit root `Dockerfile` multi-stage structure (`base` → `build` → `api`/`ui`)
-- [x] Audit root `.dockerignore` (per-package files intentionally skipped — the single root build context makes them redundant)
-- [x] Verify API image builds and runs independently (`docker build --target api` + smoke test)
-- [x] Verify UI image builds and runs independently (`docker build --target ui` + smoke test; uses Next.js standalone output)
+- [x] Split production Dockerfiles per package (`packages/api/Dockerfile`, `packages/ui/Dockerfile`)
+- [x] Each Dockerfile installs only its own workspace-filtered deps (`pnpm install --filter <pkg>...`)
+- [x] Verify API image builds and runs independently (`docker build -f packages/api/Dockerfile .` + smoke test)
+- [x] Verify UI image builds and runs independently (`docker build -f packages/ui/Dockerfile .` + smoke test; uses Next.js standalone output)
 - [x] Verify full stack via `compose.prod.yml` (`pnpm prod`)
+- [x] Verify `pnpm dev` is unaffected (native processes + DB-only compose)
 
 ### CI Pipeline (GitHub Actions)
 
@@ -68,6 +66,13 @@ Establish a fast, reliable CI pipeline using Turborepo for monorepo-aware build 
 
 - Section scope revised: the original checklist assumed per-package Dockerfiles, but the monorepo uses a single root `Dockerfile` with targeted stages (`--target api`, `--target ui`) — that work landed in Module 01 (`9582946`). Keeping this pattern because it shares the install + build steps across both targets, which is well-suited to a pnpm monorepo.
 - Pinned the Docker base image and `.nvmrc` to `node:24.14.0-slim` / `24.14.0` so CI, prod containers, and local dev all resolve to the same Node version.
+
+### 2026-04-20 — Split Dockerfiles per package (revisiting the 04-13 decision)
+
+- Reversed the earlier decision to keep a single root `Dockerfile`. The shared `build` stage looked like reuse, but `@ttis/api` and `@ttis/ui` share only `graphql` at runtime and no workspace-internal deps. Every `docker build` was installing both packages' deps, running `prisma generate` + `tsc` + `next build`, then pruning 80% of the work away via `pnpm deploy`. That's false coupling disguised as sharing.
+- New layout: `packages/api/Dockerfile` and `packages/ui/Dockerfile`. Each uses `pnpm install --filter <pkg>...` so only that package's deps (and its workspace transitives) land in `node_modules`. Each CI matrix job now builds only its own image.
+- The UI Dockerfile is notably simpler: no `pnpm deploy` step, because `next build` with `output: 'standalone'` produces a self-contained runtime tree. Added `outputFileTracingRoot: path.join(__dirname, '../../')` to `next.config.mjs` so the Next.js tracer resolves symlinked pnpm deps correctly when the build context is the repo root.
+- `compose.prod.yml` now references each package's Dockerfile directly (no `target:` field needed). `pnpm dev` is unchanged — it uses `compose.dev.yml` (DB only) plus native hot-reload processes.
 
 ### 2026-04-13 — CI workflow
 

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -3,18 +3,24 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
-# -- Install all deps and build everything --
+# -- Install api deps and build --
 FROM base AS build
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
-COPY . /app
 WORKDIR /app
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-RUN pnpm run -r build
-RUN pnpm deploy --legacy --filter=@ttis/api --prod /prod/api
-RUN pnpm deploy --legacy --filter=@ttis/ui --prod /prod/ui
 
-# -- API production image --
-FROM base AS api
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/api/package.json ./packages/api/
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @ttis/api...
+
+COPY packages/api ./packages/api
+RUN pnpm --filter @ttis/api build
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm deploy --legacy --filter=@ttis/api --prod /prod/api
+
+# -- Runtime image --
+FROM base AS runtime
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /prod/api/node_modules ./node_modules
@@ -24,11 +30,3 @@ COPY --from=build /app/packages/api/prisma/schema.prisma ./build/prisma/schema.p
 COPY --from=build /app/packages/api/prisma/migrations ./build/prisma/migrations
 EXPOSE 4000
 CMD ["node", "./build/src/index.js"]
-
-# -- UI production image --
-FROM base AS ui
-WORKDIR /app
-COPY --from=build /app/packages/ui/.next/standalone ./
-COPY --from=build /app/packages/ui/.next/static ./packages/ui/.next/static
-EXPOSE 3000
-CMD ["node", "packages/ui/server.js"]

--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:24.14.0-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# -- Install ui deps and build --
+FROM base AS build
+WORKDIR /app
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/ui/package.json ./packages/ui/
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @ttis/ui...
+
+COPY packages/ui ./packages/ui
+RUN pnpm --filter @ttis/ui build
+
+# -- Runtime image (Next.js standalone output is self-contained) --
+FROM base AS runtime
+WORKDIR /app
+COPY --from=build /app/packages/ui/.next/standalone ./
+COPY --from=build /app/packages/ui/.next/static ./packages/ui/.next/static
+EXPOSE 3000
+CMD ["node", "packages/ui/server.js"]

--- a/packages/ui/next.config.mjs
+++ b/packages/ui/next.config.mjs
@@ -4,10 +4,14 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const isProdBuild = process.env.NODE_ENV === "production";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone",
-  outputFileTracingRoot: path.join(__dirname, "../../"),
+  ...(isProdBuild && {
+    output: "standalone",
+    outputFileTracingRoot: path.join(__dirname, "../../"),
+  }),
 };
 
 export default nextConfig;

--- a/packages/ui/next.config.mjs
+++ b/packages/ui/next.config.mjs
@@ -1,8 +1,13 @@
 // @ts-check
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  outputFileTracingRoot: path.join(__dirname, "../../"),
 };
 
 export default nextConfig;

--- a/turbo.json
+++ b/turbo.json
@@ -1,18 +1,22 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
+    "generate": {
+      "inputs": ["prisma/**"],
+      "outputs": ["lib/**"]
+    },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["build/**", ".next/**", "!.next/cache/**", "src/generated/**"]
+      "outputs": ["build/**", ".next/**", "!.next/cache/**", "lib/**"]
     },
     "lint": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["generate", "^build"]
     },
     "types": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["generate", "^build"]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["generate", "^build"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary

Replace the monolithic root Dockerfile with per-package Dockerfiles. The old single file installed both packages' deps and ran every build step (prisma generate, tsc, next build) for every image, then pruned 80% away via `pnpm deploy`. `@ttis/api` and `@ttis/ui` share only `graphql` at runtime and no workspace-internal deps — the "sharing" was false coupling.

- `packages/api/Dockerfile`: api-only install via `pnpm install --filter @ttis/api...`, prisma generate + tsc, pnpm deploy for runtime
- `packages/ui/Dockerfile`: ui-only install, `next build`; runtime image copies only `.next/standalone` + `.next/static` (no pnpm deploy needed — Next.js standalone output is self-contained)
- `next.config.mjs`: gate `output: "standalone"` and `outputFileTracingRoot` on `NODE_ENV === "production"` so `next build` still emits a standalone bundle rooted at the monorepo, while `next dev` (Turbopack) isn't pointed at the repo root — earlier always-on config pulled the full ~1.6 GB hoisted pnpm `node_modules` into Turbopack's workspace scope and OOMed the dev host
- `compose.prod.yml`: reference each Dockerfile directly, drop `target:`
- `ci.yml`: matrix job picks dockerfile by package instead of `--target`
- `turbo.json`: add a `generate` turbo task and declare `types`/`lint`/`test` depend on it, so a fresh CI checkout runs `prisma generate` before `tsc` (fixes TS2307 on api's generated prisma client + pothos type imports — regression only visible in CI because local checkouts carry a prior `lib/`)

## Test plan

- [x] `pnpm prod` builds both images and serves end-to-end locally (UI homepage 200; `fetchVenues` GraphQL query returns DB-backed data)
- [x] CI-style `docker build -f packages/{api,ui}/Dockerfile .` succeeds for both images
- [x] `pnpm dev` is memory-stable and hot-reloads normally
- [x] `pnpm types` passes locally against a wiped `packages/api/lib/` + cleared turbo cache (reproduces the CI environment and confirms the `generate` dep fix)
- [ ] CI `Lint, Types, Test, Build` job goes green on this PR
- [ ] CI publish matrix runs on merge and pushes both images to ECR

🤖 Generated with [Claude Code](https://claude.com/claude-code)