### PR TITLE
Module 02: Fix ECR publish job name to use matrix.package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm build
 
   publish:
-    name: Publish ${{ matrix.target }} to ECR
+    name: Publish ${{ matrix.package }} to ECR
     if: github.event_name == 'push'
     needs: ci
     runs-on: ubuntu-latest


### PR DESCRIPTION
Matrix uses `package`, not `target`, so the job name displayed
`${{ matrix.target }}` as empty.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
