### PR TITLE
Close out Module 02; start Module 03

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Architecture Design Document
 
-**Status:** 🟡 In Progress — Module 1 (Containerization & Local Kubernetes)
+**Status:** 🟡 In Progress — Module 3 (Cloud Infrastructure & Terraform)
 
-**Last Updated:** 2026-03-25
+**Last Updated:** 2026-04-21
 
 **Author:** Jesse Rinehart
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status
 
-**Last Updated:** 2026-04-13
+**Last Updated:** 2026-04-21
 
-**Active Module:** 2 — Build System & CI/CD Foundation
+**Active Module:** 3 — Cloud Infrastructure & Terraform
 
 > [!NOTE]
 > This document tracks current implementation state, active blockers, and in-progress work. It is expected to change frequently. For the stable target architecture, see [ARCHITECTURE.md](./ARCHITECTURE.md).
@@ -14,8 +14,8 @@ For full acceptance criteria, implementation checklists, and per-module notes, s
 | Module                                            | Focus                                | Status         | Start Date | End Date   |
 | ------------------------------------------------- | ------------------------------------ | -------------- | ---------- | ---------- |
 | [01](./modules/module-01-containerization.md)     | Containerization & Local Kubernetes  | ✅ Complete    | 2026-03-03 | 2026-04-03 |
-| [02](./modules/module-02-cicd.md)                 | Build System & CI/CD Foundation      | 🟡 In Progress | 2026-04-13 |            |
-| [03](./modules/module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | ⬜ Not Started |            |            |
+| [02](./modules/module-02-cicd.md)                 | Build System & CI/CD Foundation      | ✅ Complete    | 2026-04-13 | 2026-04-21 |
+| [03](./modules/module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | 🟡 In Progress | 2026-04-21 |            |
 | [04](./modules/module-04-auth.md)                 | Authentication & Authorization       | ⬜ Not Started |            |            |
 | [05](./modules/module-05-service-extraction.md)   | Service Extraction & Message Queue   | ⬜ Not Started |            |            |
 | [06](./modules/module-06-metrics-dashboards.md)   | Observability — Metrics & Dashboards | ⬜ Not Started |            |            |
@@ -49,6 +49,10 @@ For full acceptance criteria, implementation checklists, and per-module notes, s
 - Prisma migration Job for database schema deployment in K8s
 - Seed data pipeline: CSV → JSON → Prisma seed script (~500 concert records)
 - Turborepo task pipelines (build, lint, test, types) with Vercel remote caching
+- GitHub Actions CI pipeline (lint, types, test, build) on every PR and push to `main`
+- Per-package production Dockerfiles (`packages/api/Dockerfile`, `packages/ui/Dockerfile`) with workspace-filtered installs
+- Automated ECR publish on merge to `main`: OIDC-authenticated push of `ttis-api` and `ttis-ui` images tagged with short git SHA and `latest`
+- AWS setup scripted via `scripts/setup-ecr-repos.sh` and `scripts/setup-github-oidc.sh` (ECR lifecycle policies retain last 5 tagged images)
 
 ## Active Blockers
 
@@ -61,4 +65,4 @@ None — all Module 1 prerequisite blockers have been resolved:
 
 ## Active Module Detail
 
-See [Module 02](./modules/module-02-cicd.md) for the full acceptance criteria checklist and in-progress notes.
+Module 02 is complete. Module 03 (Cloud Infrastructure & Terraform) started 2026-04-21 — the AWS account and CLI setup checklist items were picked up during Module 02's ECR publish work. See [Module 03](./modules/module-03-cloud-infrastructure.md) for the in-progress checklist and [Module 02](./modules/module-02-cicd.md) for the just-finished phase's wrap-up notes.

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -6,15 +6,15 @@ For the high-level status snapshot, see [STATUS.md](../STATUS.md). For architect
 
 ## Modules
 
-| Module                                    | Focus                                | Status         | Start Date | End Date |
-| ----------------------------------------- | ------------------------------------ | -------------- | ---------- | -------- |
-| [01](./module-01-containerization.md)     | Containerization & Local Kubernetes  | 🟡 In Progress | 2026-03-03 |          |
-| [02](./module-02-cicd.md)                 | Build System & CI/CD Foundation      | ⬜ Not Started |            |          |
-| [03](./module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | ⬜ Not Started |            |          |
-| [04](./module-04-auth.md)                 | Authentication & Authorization       | ⬜ Not Started |            |          |
-| [05](./module-05-service-extraction.md)   | Service Extraction & Message Queue   | ⬜ Not Started |            |          |
-| [06](./module-06-metrics-dashboards.md)   | Observability — Metrics & Dashboards | ⬜ Not Started |            |          |
-| [07](./module-07-logging-tracing.md)      | Observability — Logging & Tracing    | ⬜ Not Started |            |          |
-| [08](./module-08-alerting.md)             | Alerting & Incident Response         | ⬜ Not Started |            |          |
-| [09](./module-09-gitops.md)               | GitOps & Advanced Deployment         | ⬜ Not Started |            |          |
-| [10](./module-10-chaos.md)                | Chaos Engineering & Polish           | ⬜ Not Started |            |          |
+| Module                                    | Focus                                | Status         | Start Date | End Date   |
+| ----------------------------------------- | ------------------------------------ | -------------- | ---------- | ---------- |
+| [01](./module-01-containerization.md)     | Containerization & Local Kubernetes  | ✅ Complete    | 2026-03-03 | 2026-04-03 |
+| [02](./module-02-cicd.md)                 | Build System & CI/CD Foundation      | ✅ Complete    | 2026-04-13 | 2026-04-21 |
+| [03](./module-03-cloud-infrastructure.md) | Cloud Infrastructure & Terraform     | 🟡 In Progress | 2026-04-21 |            |
+| [04](./module-04-auth.md)                 | Authentication & Authorization       | ⬜ Not Started |            |            |
+| [05](./module-05-service-extraction.md)   | Service Extraction & Message Queue   | ⬜ Not Started |            |            |
+| [06](./module-06-metrics-dashboards.md)   | Observability — Metrics & Dashboards | ⬜ Not Started |            |            |
+| [07](./module-07-logging-tracing.md)      | Observability — Logging & Tracing    | ⬜ Not Started |            |            |
+| [08](./module-08-alerting.md)             | Alerting & Incident Response         | ⬜ Not Started |            |            |
+| [09](./module-09-gitops.md)               | GitOps & Advanced Deployment         | ⬜ Not Started |            |            |
+| [10](./module-10-chaos.md)                | Chaos Engineering & Polish           | ⬜ Not Started |            |            |

--- a/docs/modules/module-02-cicd.md
+++ b/docs/modules/module-02-cicd.md
@@ -1,10 +1,10 @@
 # Module 02: Build System & CI/CD Foundation
 
-**Status:** 🟡 In Progress
+**Status:** ✅ Complete
 
 **Start Date:** 2026-04-13
 
-**End Date:** —
+**End Date:** 2026-04-21
 
 ## Goal
 
@@ -38,16 +38,16 @@ Establish a fast, reliable CI pipeline using Turborepo for monorepo-aware build 
 
 ### Container Registry
 
-- [ ] Set up AWS ECR repositories (ttis-api, ttis-ui) with lifecycle policies
-- [ ] Configure GitHub OIDC for AWS IAM role assumption
-- [ ] Add CI step to build and push Docker images to ECR on merge to main
-- [ ] Tag images with git SHA and `latest`
-- [ ] Verify images are pullable from ECR
+- [x] Set up AWS ECR repositories (ttis-api, ttis-ui) with lifecycle policies
+- [x] Configure GitHub OIDC for AWS IAM role assumption
+- [x] Add CI step to build and push Docker images to ECR on merge to main
+- [x] Tag images with git SHA and `latest`
+- [x] Verify images are pullable from ECR
 
 ### Verification
 
-- [ ] End-to-end: open PR → CI passes → merge → images published to ECR
-- [ ] Document pipeline architecture and caching strategy
+- [x] End-to-end: open PR → CI passes → merge → images published to ECR
+- [x] Document pipeline architecture and caching strategy
 
 ## Related ADRs
 

--- a/docs/modules/module-03-cloud-infrastructure.md
+++ b/docs/modules/module-03-cloud-infrastructure.md
@@ -1,8 +1,8 @@
 # Module 03: Cloud Infrastructure & Terraform
 
-**Status:** ⬜ Not Started
+**Status:** 🟡 In Progress
 
-**Start Date:** —
+**Start Date:** 2026-04-21
 
 **End Date:** —
 
@@ -14,8 +14,8 @@ Provision all cloud infrastructure via Terraform and deploy the application to A
 
 ### Setup
 
-- [ ] Set up AWS account (or use existing)
-- [ ] Install AWS CLI and configure credentials
+- [x] Set up AWS account (or use existing)
+- [x] Install AWS CLI and configure credentials
 - [ ] Install Terraform
 - [ ] Complete a basic Terraform tutorial (provision an S3 bucket, then destroy it)
 
@@ -53,3 +53,7 @@ _None yet. Add links here as decisions are made during this module._
 ## Notes & Discoveries
 
 > Capture decisions made on the fly, unexpected findings, or context that doesn't warrant a full ADR. Append entries as you go.
+
+### 2026-04-21 — AWS account and CLI already configured from Module 02
+
+- The AWS account and local AWS CLI setup were prerequisites for Module 02's ECR publish work — `scripts/setup-ecr-repos.sh` and `scripts/setup-github-oidc.sh` both require an AWS CLI configured with admin access. Those prerequisites spilled into this module's "Setup" checklist and were completed during Module 02.


### PR DESCRIPTION
## Summary

- Module 02 (Build System & CI/CD Foundation) is complete as of 2026-04-21: all remaining Container Registry and Verification boxes are checked (ECR repos with lifecycle policies, GitHub OIDC, SHA/`latest`-tagged publish on merge to main, end-to-end PR→publish flow).
- Module 03 (Cloud Infrastructure & Terraform) flips to In Progress with the same start date. Its AWS account and AWS CLI setup items were completed during Module 02's ECR work (the setup scripts required a configured AWS CLI), so those two boxes are already checked with a notes entry explaining why.
- Status snapshot, module index, ARCHITECTURE header, and "What Is Working" section all refreshed to reflect the new state.

Docs-only — no code changes.

## Test plan

- [x] Rendered module-02-cicd.md shows status ✅ Complete and end date 2026-04-21; every acceptance-criteria checkbox is ticked.
- [x] Rendered module-03-cloud-infrastructure.md shows status 🟡 In Progress with start date 2026-04-21; first two Setup checkboxes ticked; notes entry explains the spillover from Module 02.
- [x] docs/STATUS.md and docs/modules/README.md tables match the new module statuses.
- [x] docs/ARCHITECTURE.md header reflects Module 3 as the current phase.
- [x] CI passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)