### PR TITLE
chore: add Claude skills, types hook, and refresh CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": []
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm -w types 2>&1 | tail -20"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: commit-pr
 description: Commit staged changes, push branch, open PR, and update status docs
+model: sonnet
+effort: medium
 ---
 
-1. Do everything in `/commit` skill
-2. Run `gh pr create`
-3. Report PR number and URL
-4. Open the PR in web browser
+Prerequisite: Do everything in `/commit` skill
+
+If no PR currently exists for this branch...
+
+1. Run `gh pr create`
+1. Report PR number and URL
+1. Open the PR in web browser
+
+If a PR _already_ exists for this branch and there are new changes...
+
+1. Run `/commit` skill first
+1. Push up commit(s) to remote branch
+1. Update the PR description, if necessary
+1. Open the PR in web browser

--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: commit-pr
+description: Commit staged changes, push branch, open PR, and update status docs
+---
+
+1. Do everything in `/commit` skill
+2. Run `gh pr create`
+3. Report PR number and URL
+4. Open the PR in web browser

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: commit
 description: Commit staged changes
+model: sonnet
+effort: medium
 ---
 
 1. Review `git status` and `git diff --staged`. Do not include any unstaged changes without asking permission.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: commit
+description: Commit staged changes
+---
+
+1. Review `git status` and `git diff --staged`. Do not include any unstaged changes without asking permission.
+1. Verify `@docs/STATUS.md` and relevant module README (`@docs/modules/*`) are updated for the change, if necessary
+1. Create a new branch, if needed (never `main`)
+1. Commit. Wait for `lint-staged` pre-commit checks to complete successfully, propose a conventional commit message, and wait for approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,17 @@ A concert/event tracking and visualization app. Monorepo with pnpm workspaces co
 See `docs/ARCHITECTURE.md` for the full target architecture and ADR log.
 See `docs/STATUS.md` for current implementation state and active blockers.
 
+## Approach Before Action
+
+- For Docker/infra changes, propose the approach (e.g., Dockerfile edit vs compose.yml env_file) BEFORE editing files
+- Don't install system tools (brew/apt) without explicit approval
+- If a fix path gets long (>2 failed attempts), stop and summarize alternatives before continuing
+- Always verify the installed version of a package and check current docs before writing.
+
+## Use Task Agents for multi-issue debugging
+
+When a session has multiple independent bugs or tasks that can be run in parallel, use a separate Task agent to investigate each one in parallel in its own scope, then report findings before making any fixes.
+
 ## Common Commands
 
 ### Development
@@ -35,7 +46,7 @@ pnpm prod:down             # Stop the production stack
 
 ```bash
 pnpm test                  # Run tests across all packages (Vitest)
-pnpm --filter @ttis/ui test  # Run tests in a specific package
+pnpm --filter @ttis/api test # Run tests in a specific package
 ```
 
 ### Linting
@@ -45,10 +56,28 @@ pnpm lint                  # Lint all packages
 pnpm --filter @ttis/api lint # Lint a specific package
 ```
 
+### Type Checking
+
+```bash
+pnpm types                 # Type-check all packages
+```
+
+### Formatting
+
+```bash
+pnpm format                # Run Prettier across all packages
+```
+
 ### Building
 
 ```bash
 pnpm build                 # Build all packages
+```
+
+### Data Scripts
+
+```bash
+pnpm parse-csv             # Parse source CSV data (data/scripts/parse-csv.ts)
 ```
 
 ### Package-Specific
@@ -81,17 +110,20 @@ pnpm --filter @ttis/ui add <dep>    # Add dep to UI package
 
 UI (Apollo Client) → GraphQL API (GraphQL Yoga + Pothos) → Prisma ORM → PostgreSQL
 
-### API Package (`packages/api/src`)
+### API Package (`packages/api`)
 
-- **schema/** - Pothos schema builders (event.ts, venue.ts, genre.ts)
+- **src/schema/** - Pothos schema builders (builder.ts, event.ts, venue.ts, genre.ts, index.ts)
+- **src/db/** - Prisma client instance (prisma.ts)
+- **src/config.ts** - Environment/config loading
+- **src/index.ts** - GraphQL Yoga server entry point
 - **prisma/** - Prisma schema, migrations, generated client
-- **index.ts** - GraphQL Yoga server entry point
 
 ### UI Package (`packages/ui/src`)
 
 - **app/** - Next.js App Router pages (home, about, events, venues)
 - **components/** - React components and shadcn/ui primitives
 - **graphql/** - Apollo queries and mutations
+- **lib/** - Shared utilities (e.g., shadcn `cn` helper)
 
 ### Key Patterns
 
@@ -110,6 +142,13 @@ UI (Apollo Client) → GraphQL API (GraphQL Yoga + Pothos) → Prisma ORM → Po
 - **Never commit directly to `main`.** Always ensure you are on a feature branch before committing changes.
 - If currently on `main`, create a new branch before making any commits.
 
+## Stack Conventions
+
+- Prisma 7 config syntax (not legacy seed config)
+- ESM imports require explicit `.js` extensions
+- Next.js standalone output requires manual static file copying
+- Turborepo: ensure `prisma generate` is declared as a task dependency
+
 ## Documentation Maintenance
 
 When committing changes, always review whether project documentation needs updates to reflect the work done. Documentation updates should be included in the same commit as the code changes they describe.
@@ -118,6 +157,8 @@ When committing changes, always review whether project documentation needs updat
 - **`docs/modules/*.md`** — When work completes acceptance criteria items or changes their scope, update the relevant module file's checklists and notes.
 - **`docs/ARCHITECTURE.md`** — If a change introduces or revises an architectural decision, add or update the appropriate ADR entry.
 - **`README.md` files** — When adding, removing, or renaming npm scripts, CLI commands, or setup steps, update any README that documents them to keep instructions accurate.
+
+Verify checklist items against actual code/config before marking complete.
 
 ## Document Styling Preferences
 


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with a `PostToolUse` hook that runs `pnpm -w types` after `Edit`/`Write` tool calls so Claude catches type regressions immediately.
- Add `/commit` and `/commit-pr` skills under `.claude/skills/` to codify the commit + PR workflow.
- Expand `CLAUDE.md` with new guidance sections: Approach Before Action, Task Agents for multi-issue debugging, Type Checking, Formatting, Data Scripts, Stack Conventions.
- Fix `CLAUDE.md` drift: correct the `@ttis/api test` filter (the UI package has no test script), and restructure the API package tree to reflect the current `src/schema`, `src/db`, `src/config.ts` layout with `prisma/` as a sibling of `src/`. Add UI `lib/`.

## Test plan

- [x] Open a fresh Claude Code session in this repo and confirm `/commit` and `/commit-pr` show up in the skills list.
- [ ] Trigger an Edit on any file and confirm the `PostToolUse` hook runs `pnpm -w types`.
- [ ] Spot-check the updated command/architecture sections in `CLAUDE.md` against `package.json` and the `packages/` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)